### PR TITLE
Update en/latest from v1.0.0-rc.1 to v1.0.0-rc.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,7 +32,7 @@
 
 [[redirects]]
   from = "/en/latest"
-  to = "/en/v1.0.0-rc.1"
+  to = "/en/v1.0.0-rc.2"
   force = true
 
 [[headers]]


### PR DESCRIPTION
Hi all,

Although currently the 1.0.0-rc.2 is published, it seems that the link to the latest version of the spec still points to version 1.0.0-rc.1.
This PullReq is trying to update the link. Since I'm not very familiar with netlify, if this is not sufficient, please tell me.

thanks!