### PR TITLE
Add a display: block css rule to fix no-js page

### DIFF
--- a/code/stylesheets/spec.pcss
+++ b/code/stylesheets/spec.pcss
@@ -57,6 +57,7 @@
 
     pre {
       code {
+        display: block; /* make things smooth with js disabled */
         @apply my-8 p-4 whitespace-pre;
       }
     }

--- a/code/stylesheets/spec.pcss
+++ b/code/stylesheets/spec.pcss
@@ -57,8 +57,7 @@
 
     pre {
       code {
-        display: block; /* make things smooth with js disabled */
-        @apply my-8 p-4 whitespace-pre;
+        @apply block my-8 p-4 whitespace-pre;
       }
     }
 


### PR DESCRIPTION
Otherwise `pre>code` blocks make things unreadable.

**I have not tested this change other than adding the `display: block` in the browser, i.e. I have not checked if this does properly flow through your doc-generation workflow.**

(Why is there any need for js in the first place grmbl grmbl)

Thanks for considering this PR.