### PR TITLE
Show apostrophes in multi-line literal strings

### DIFF
--- a/specs/en/index.html
+++ b/specs/en/index.html
@@ -330,6 +330,7 @@ regex = '<\i\c*\s*>'</code></pre>
             class="code toml"
             data-controller="snippet" data-snippet-copy="false"
           ><code>re = '''\d{2} apps is t[wo]o many'''
+literal-apostrophes = '''You're free to use apostrophes in here.'''
 lines = '''
 The first newline is
 trimmed in raw strings.


### PR DESCRIPTION
When I [pointed to the website](https://github.com/toml-lang/toml/issues/949#issuecomment-1377864878) when discussing how apostrophes are permitted in multi-line literal strings, I was surprised to discover that this permission is described, but it isn't made explicitly clear with an example.

This change adds such an example.

```toml
literal-apostrophes = '''You're free to use apostrophes in here.'''
```