### PR TITLE
Use single quote in multi-line literal string example.

### DIFF
--- a/specs/cn/index.html
+++ b/specs/cn/index.html
@@ -313,7 +313,7 @@ regex = '<\i\c*\s*>'</code></pre>
           <pre
             class="code toml"
             data-controller="snippet" data-snippet-copy="false"
-          ><code>re = '''\d{2} apps is t[wo]o many'''
+          ><code>re = '''I [dw]on't need \d{2} apples'''
 lines = '''
 原始字符串中的
 第一个换行被剔除了。

--- a/specs/en/index.html
+++ b/specs/en/index.html
@@ -329,7 +329,7 @@ regex = '<\i\c*\s*>'</code></pre>
           <pre
             class="code toml"
             data-controller="snippet" data-snippet-copy="false"
-          ><code>re = '''\d{2} apps is t[wo]o many'''
+          ><code>re = '''I [dw]on't need \d{2} apples'''
 lines = '''
 The first newline is
 trimmed in raw strings.

--- a/specs/fr/index.html
+++ b/specs/fr/index.html
@@ -325,7 +325,7 @@ regex = '<\i\c*\s*>'</code></pre>
           <pre
             class="code toml"
             data-controller="snippet" data-snippet-copy="false"
-          ><code>re = '''\d{2} apps is t[wo]o many'''
+          ><code>re = '''I [dw]on't need \d{2} apples'''
 lines = '''
 Le premier saut de ligne est ignoré
 dans les chaînes littérales.


### PR DESCRIPTION
Index page advetises multi-line literal string as the thing to go for if you need a single quote in your literal string. But the provided example lacks single quote symbol.