### PR TITLE
correction fr translation in example: remove the non-ASCII character from the bare-key

### DIFF
--- a/specs/fr/v1.0.0.md
+++ b/specs/fr/v1.0.0.md
@@ -18,7 +18,7 @@ Sommaire
 --------
 
 - [Spécifications](#spécifications)
-- [Commentaire](#commentaire)
+- [Commentaires](#commentaires)
 - [Paire clé/valeur](#paire-clévaleur)
 - [Clé](#clé)
 - [Chaîne](#chaîne)
@@ -91,7 +91,7 @@ Les valeurs doivent avoir l'un des types suivants.
 Les valeurs non spécifiées ne sont pas valides.
 
 ```toml
-clé = # INVALIDE
+cle = # INVALIDE
 ```
 
 Il doit y avoir un saut de ligne (ou EOF) après une paire clé/valeur. (Voir
@@ -112,9 +112,9 @@ clés nues peuvent être composées uniquement de Chiffres ASCII, par ex. `1234`
 mais sont toujours interprétées comme des chaînes.
 
 ```toml
-clé = "valeur"
+cle = "valeur"
 bare_key = "valeur"
-clé nue = "valeur"
+cle-nue = "valeur"
 1234 = "valeur"
 ```
 


### PR DESCRIPTION
In the French documentation there is a little mistake with the translation. 

* The english word `key` is translated `clé` which  is not an ASCII world. 
* And also there is a `-` translated like a space ` `. 

Both are not a valide key. 

Thank's a lot