### PR TITLE
Rename "Version" to "Full spec" at the top

### DIFF
--- a/code/html/_nav.html.template
+++ b/code/html/_nav.html.template
@@ -23,9 +23,9 @@
   <nav class="absolute top-0 right-0 mt-3 w-full md:w-auto py-1 px-2">
     <ul class="flex justify-end items-start text-orange-900 text-sm text-center">
       <li class="md:w-1/2 md:w-auto mx-2 px-2 bg-white border border-orange-300 rounded">
-        <div class="w-20">
+        <div class="w-24">
           <a href="#" class="block py-1 px-1" data-action="click->application#showVersions" data-target="application.versionsLink"
-            >Version</a
+            >Full spec</a
           >
           <ul class="hidden block my-2 px-1 text-sm leading-loose" data-target="application.versions">
             {{ versions }}


### PR DESCRIPTION
This confused me in the past; it's not super-clear that "Version" goes to the full spec.

Also make the dropdown a bit wider, so all the text fits without breaking on my system (would be even better to automatically size it, but I didn't feel like fighting this Tailwind thing).

How it currently looks:

![cap-2023-09-28T12:16:22_border](https://github.com/toml-lang/toml.io/assets/1032692/b6bdb7bd-cacb-4371-94c6-4779edd6efcb)
