### PR TITLE
Fix navigation when window is zoomed

### DIFF
--- a/code/javascripts/controllers/nav_controller.js
+++ b/code/javascripts/controllers/nav_controller.js
@@ -20,20 +20,18 @@ export default class extends Controller {
   }
 
   scroll() {
-    console.log("scroll");
     let scrolledElements = this.headerTargets
       .map(target => {
-        if (target.offsetTop <= window.scrollY) {
+        if (target.offsetTop <= Math.ceil(window.scrollY)) {
           return target;
         }
       })
       .filter(target => target);
-    let id = null;
 
     this.linkTargets.forEach(target => target.classList.remove("active"));
 
     if (scrolledElements.length) {
-      id = scrolledElements.pop().id;
+      let id = scrolledElements.pop().id;
 
       this.linkTargets
         .find(target => {


### PR DESCRIPTION
In Firefox when zoomed to 120%, clicking on a menu item on /en/v1.0.0.html will highlight the entry above it, rather than the entry we clicked on.

the problem is that the scroll value may not be a full pixel anymore, for example after clicking "Integer":

	console.log(target, target.offsetTop, window.scrollY)
	// <h2 id="string"  data-target="nav.header"> 5828 9511.6669921875
	// <h2 id="integer" data-target="nav.header"> 9512 9511.6669921875

Doing a Math.ceil() fixes it. Round is not enough as some values are below .5