### PR TITLE
Add date to spec, translate "Text version"

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -8,6 +8,41 @@ const entities = new Entities();
 
 const TABLE_OF_CONTENTS_POSITION = 2;
 
+let versionDates = {
+  'v0.1.0':      new Date('2013-03-17'),
+  'v0.2.0':      new Date('2013-09-24'),
+  'v0.3.0':      new Date('2014-11-10'),
+  'v0.3.1':      new Date('2014-11-11'),
+  'v0.4.0':      new Date('2015-02-12'),
+  'v0.5.0':      new Date('2018-07-10'),
+  'v1.0.0-rc.1': new Date('2020-04-03'),
+  'v1.0.0-rc.2': new Date('2020-08-09'),
+  'v1.0.0-rc.3': new Date('2020-10-07'),
+  'v1.0.0':      new Date('2021-01-11'),
+}
+
+let i18n = {
+  published: {
+    en:      'Published on %(date)',
+    'zh-CN': '发布于 %(date)',
+    fr:      'Publié le %(date)',
+    ja:      '%(date) 日掲載',
+    ko:      '%(date) 에 게시됨',
+    pl:      'Opublikowano dnia %(date) r.',
+    pt:      'Publicado em %(date)',
+  },
+  textVersion: {
+    en:      'Text version',
+    'zh-CN': '文本版本',
+    fr:      'Version texte',
+    ja:      'テキスト版',
+    ko:      '텍스트 버전',
+    pl:      'Wersja tekstowa',
+    pt:      'Versão de texto',
+  }
+}
+
+
 module.exports = class Formatter {
   static textFromHeader(text) {
     const html = entities.decode(text);
@@ -70,6 +105,14 @@ module.exports = class Formatter {
   }
 
   static addTextLink(html, locale, version) {
-    return html.replace(/<h1/, `<a class="block text-left md:text-right mt-16 md:mt-0" href="https://raw.githubusercontent.com/toml-lang/toml.io/main/specs/${locale}/${version}.md" class="text-link text-sm">Text Version</a>\n<h1`)
+    let l = locale === 'cn' ? 'zh-CN' : locale,
+        d = new Intl.DateTimeFormat(l, {dateStyle: 'long'}).format(versionDates[version]),
+        p = (i18n.published[l] || i18n.published['en']).replace(/%\(date\)/, d),
+        t = (i18n.textVersion[l] || i18n.textVersion['en'])
+    return html.replace(/<h1/, `
+      <span class="block text-left md:text-right mt-16 md:mt-0">
+        ${p} – <a href="https://raw.githubusercontent.com/toml-lang/toml.io/main/specs/${locale}/${version}.md">${t}</a>
+      </span>
+      <h1`)
   }
 };

--- a/lib/spec_to_html.js
+++ b/lib/spec_to_html.js
@@ -86,7 +86,8 @@ class SpecToHtml {
 
   generateSpecs() {
     fs.readdirSync(SPEC_DIR).forEach(locale => {
-      if (!this.shouldGenerate(locale)) return;
+      if (!this.shouldGenerate(locale))
+        return;
 
       console.info(`\nWorking on ${locale} locale...`);
       console.group();
@@ -138,10 +139,9 @@ class SpecToHtml {
     for (let locale in this.generatedSpecs) {
       const navOutputPath = path.join(HTML_DIR, locale, "_nav.html");
       const versions = this.generatedSpecs[locale];
-      const versionsList = [];
 
-      versions.reverse().forEach(version => {
-        versionsList.push(`<li data-target="application.version" data-version="${version}"><a href="/${locale}/${version}.html">${version}</a></li>`);
+      const versionsList = versions.reverse().map(version => {
+        return `<li data-target="application.version" data-version="${version}"><a href="/${locale}/${version}.html">${version}</a></li>`;
       });
 
       const output = NAV_TEMPLATE


### PR DESCRIPTION
This adds the date to the top of every spec. I also noticed the "Text version" was always in English, so translate that too.

(I machine translated the texts, but DeepL and Google Translate seem to agree, and a quick search seems to verify they're not horrible wrong, so should be good).

Just keep a manual list of the dates. Otherwise it's spending half an hour or more to automate about 1 minute of work every few years.

Fixes #12

![cap-2023-10-12T01:29:08_border](https://github.com/toml-lang/toml.io/assets/1032692/6bdf8c5a-97bd-4f65-933f-e24989b09cd5)
