### PR TITLE
Fix some mistakes in pl-PL translation

### DIFF
--- a/specs/pl/v1.0.0.md
+++ b/specs/pl/v1.0.0.md
@@ -670,8 +670,8 @@ zawierają wartości.
 [tabela]
 ```
 
-Pod tym do następnego nagłówka lub końca pliku są wartości klucz/wartość danej
-tabeli. Nie jest gwarantowane, żeby wartości klucz/wartość w tabelach miały
+Pod tym do następnego nagłówka lub końca pliku są pary klucz/wartość danej
+tabeli. Nie jest gwarantowane, żeby pary klucz/wartość w tabelach miały
 określoną kolejność.
 
 ```toml
@@ -791,7 +791,7 @@ owoc.jablko.smak.slodki = true
 ```
 
 Ponieważ tabel nie można zdefiniować więcej niż raz, ponowne definiowanie takich
-tabel używając `[naglowka]` nie jest dozwolone. Tak samo używanie kluczy
+tabel za pomocą `[naglowka]` nie jest dozwolone. Tak samo używanie kluczy
 przedzielonych kropkami już zdefiniowanych w formie `[tabeli]` nie jest dozwolone.
 Jednak forma `[tabeli]` może być użyta do zdefiniowana podtabel w tabelach
 zdefiniowanych kluczami przedzielonymi kropkami.
@@ -968,7 +968,7 @@ nazwa = "jabłko"
 ```
 
 Próba dołączenia do statycznie zdefiniowanej listy, nawet jeśli ta lista jest
-pusta musi wypisać błąd podczas przetwarzania.
+pusta, musi wypisać błąd podczas przetwarzania.
 
 ```
 # NIEPRAWIDŁOWY DOKUMENT TOML
@@ -978,7 +978,7 @@ owoce = []
 ```
 
 Próby zdefiniowania normalnej tabeli z tą samą nazwą, co już jest ustalone jako
-lista musi wypisać błąd podczas przetwarzania. Tak samo jest w przypadku próby
+lista, musi wypisać błąd podczas przetwarzania. Tak samo jest w przypadku próby
 ponownej definicji normalnej tabeli jako lista.
 
 ```


### PR DESCRIPTION
- Added commas where needed (two instances)
- Changed "key/value values" to "key/value pairs" (two instances)
- Fix a grammar non-error that even AI proofreaders (like LanguageTool) think it's an error