### PR TITLE
Add Rust, adjust case, order, use ellipsis Unicode character

### DIFF
--- a/specs/cn/index.html
+++ b/specs/cn/index.html
@@ -236,7 +236,7 @@ role = "后端"</code></pre>
         </dt>
         <dd class="text-gray-600 ml-13">
           <p class="ml-1">
-            TOML 已经拥有大多数当今使用的最流行的编程语言的实现：C、C#、C++、Clojure、Dart、Elixir、Erlang、Go、Haskell、Java、Javascript、Lua、Objective-C、Perl、PHP、Python、Ruby、Swift、Scala……<a class="underline" href="https://github.com/toml-lang/toml/wiki">以及更多</a>。
+            TOML 已经拥有大多数当今使用的最流行的编程语言的实现：C、C#、C++、Clojure、Dart、Elixir、Erlang、Go、Haskell、Java、JavaScript、Lua、Objective-C、Perl、PHP、Python、Ruby、Rust、Scala、Swift…<a class="underline" href="https://github.com/toml-lang/toml/wiki">以及更多</a>。
           </p>
         </dd>
       </div>

--- a/specs/en/index.html
+++ b/specs/en/index.html
@@ -240,8 +240,8 @@ role = "backend"</code></pre>
         <dd class="text-gray-600 ml-13">
           <p class="ml-1">
             TOML already has implementations in most of the most popular programming languages in use
-            today: C, C#, C++, Clojure, Dart, Elixir, Erlang, Go, Haskell, Java, Javascript, Lua,
-            Objective-C, Perl, PHP, Python, Ruby, Swift, Scala...
+            today: C, C#, C++, Clojure, Dart, Elixir, Erlang, Go, Haskell, Java, JavaScript, Lua,
+            Objective-C, Perl, PHP, Python, Ruby, Rust, Scala, Swift, …
             <a class="underline" href="https://github.com/toml-lang/toml/wiki">and plenty more</a>.
           </p>
         </dd>

--- a/specs/fr/index.html
+++ b/specs/fr/index.html
@@ -240,7 +240,7 @@ role = "backend"</code></pre>
           <p class="ml-1">
             TOML a déjà des implementations dans la plupart des plus populaires langages de
             programmation actuels : C, C#, C++, Clojure, Dart, Elixir, Erlang, Go, Haskell,
-            Java, Javascript, Lua, Objective-C, Perl, PHP, Python, Ruby, Swift, Scala...
+            Java, JavaScript, Lua, Objective-C, Perl, PHP, Python, Ruby, Rust, Scala, Swift, …
             <a class="underline" href="https://github.com/toml-lang/toml/wiki">et plein d'autres</a>.
           </p>
         </dd>

--- a/specs/pl/index.html
+++ b/specs/pl/index.html
@@ -240,7 +240,7 @@ role = "backend"</code></pre>
           <p class="ml-1">
             TOML już ma implementacje w większości popularnych języków programowania w użytku do dziś:
             C, C#, C++, Clojure, Dart, Elixir, Erlang, Go, Haskell, Java, JavaScript, Lua,
-            Objective-C, Perl, PHP, Python, Ruby, Swift, Scala...
+            Objective-C, Perl, PHP, Python, Ruby, Rust, Scala, Swift, …
             <a class="underline" href="https://github.com/toml-lang/toml/wiki">i wielu więcej</a>.
           </p>
         </dd>

--- a/specs/pt/index.html
+++ b/specs/pt/index.html
@@ -241,7 +241,7 @@ role = "backend"</code></pre>
           <p class="ml-1">
             O TOML já possui implementações na maioria das linguagens de programação mais populares
             em uso atualmente: C, C#, C++, Clojure, Dart, Elixir, Erlang, Go, Haskell, Java,
-            Javascript, Lua, Objective-C, Perl, PHP, Python, Ruby, Swift, Scala...
+            JavaScript, Lua, Objective-C, Perl, PHP, Python, Ruby, Rust, Scala, Swift, …
             <a class="underline" href="https://github.com/toml-lang/toml/wiki">e muito mais</a>.
           </p>
         </dd>


### PR DESCRIPTION
- Mention Rust on the homepage. Given that Cargo uses it since quite a while ago, and AFAIK for longer than at least some other languages and their ecosystems do, I think it's appropriate to include Rust in this list.
- It's "JavaScript".
- Follow alphabetical order.
- Use the ellipsis Unicode character.